### PR TITLE
fix: double scrollbar when displayed in an iframe

### DIFF
--- a/bindata/static/css/index.css
+++ b/bindata/static/css/index.css
@@ -1,3 +1,6 @@
+html {
+    overflow: hidden; /* prevent double scrollbar when in an iframe */
+}
 html, body, #terminal {
     background: #2e3131;
     height: 100%;

--- a/resources/index.css
+++ b/resources/index.css
@@ -1,3 +1,6 @@
+html {
+    overflow: hidden; /* prevent double scrollbar when in an iframe */
+}
 html, body, #terminal {
     background: #2e3131;
     height: 100%;


### PR DESCRIPTION
prevent html element to scroll when embedded in an iframe